### PR TITLE
Fix black screen/buffer timeout issue on playback stop (LibreELEC)

### DIFF
--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -1,0 +1,46 @@
+# Fork Changes
+
+## v1.3.1 - Black Screen Fix (January 2026)
+
+### Issue
+On LibreELEC, pressing Back during playback resulted in:
+- Black screen with no UI
+- Debug logs showing `------ Window Init () ------` (empty window ID)
+- Continuous `OutputPicture - timeout waiting for buffer` errors
+- Orphaned player instance causing audio/video stream stalls
+
+### Root Cause
+The addon created an empty `backWindow` (xbmcgui.Window()) and showed it before starting playback. This window became the "previous window" in Kodi's navigation stack. When pressing Back from fullscreen video, Kodi would deinitialize VideoFullScreen.xml and attempt to activate this empty window, resulting in an invalid window state.
+
+The empty window was originally added in v1.1.2 to "prevent Kodi from being displayed between Playlist Shuffles", but it caused unintended side effects with window management.
+
+### Fix
+1. **Removed the `backWindow` creation entirely** - No longer create or show an empty window
+2. **Navigate to Home screen before starting playback** - This sets Home as the proper "previous window" in Kodi's navigation stack
+3. **Explicitly stop player before script exit** - Prevents orphaned player instances that cause buffer timeouts
+4. **Navigate back to Home screen during cleanup** - Ensures proper window state on exit
+
+### Code Changes
+- **Line 129-130**: Added `ActivateWindow(home)` before starting playback instead of creating backWindow
+- **Line 58-60**: Removed callback-based navigation (not needed with new approach)
+- **Line 210**: Removed backWindow.close() from no-episodes exit path
+- **Line 344-353**: Added explicit player.stop() and navigation to Home in cleanup section
+
+### Testing
+Tested on LibreELEC with Kodi Matrix. Pressing Back now properly returns to Home screen without black screens or buffer errors.
+
+### Technical Details
+The issue occurred because:
+1. `backWindow = xbmcgui.Window()` creates a window with no XML definition
+2. `backWindow.show()` makes it the active window and adds it to navigation stack
+3. Starting video playback makes VideoFullScreen.xml active, with backWindow as "previous"
+4. Pressing Back triggers `CGUIWindowManager::PreviousWindow`
+5. Kodi deinitializes VideoFullScreen and tries to activate backWindow
+6. Since backWindow has no window ID or XML, it shows as `Window Init ()`
+7. The player instance continues running but with no valid output window, causing buffer timeouts
+
+By navigating to Home before playback, the navigation stack becomes:
+1. Home → VideoFullScreen (instead of backWindow → VideoFullScreen)
+2. Pressing Back properly returns to Home
+3. No orphaned player, no buffer timeouts
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # script.video.randomtv
 Kodi Addon: RandomTV
 
+## Fork Notice
+This is a fork of the original [script.video.randomtv](https://github.com/gmccauley/script.video.randomtv) by gmccauley.
+
+### Changes in this fork:
+- **v1.3.1 (Jan 2026)**: Fixed black screen/buffer timeout issue on LibreELEC when pressing Back during playback. The original addon created an empty window that caused Kodi's window manager to initialize an empty window ID, resulting in black screens and orphaned player instances with continuous buffer timeout errors.
+
+---
+
 I searched for an addon to play Random TV Episodes from my library and while I found a few, none were really what I wanted. So what's a guy to do? Write his own addon of course. :D
 
 I'm a little anal when it comes to watched status and stuff in my library with the "in progress" icon, so one of my biggest requirements was to be able to not update the Play Count or resume info. So basically, I wanted an addon that would set the playcount and resume info back to what it was before playing.

--- a/addon.py
+++ b/addon.py
@@ -120,11 +120,14 @@ if len(sys.argv) > 1:
 
 
 # Display Starting Notification
-if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, addon.getLocalizedString(32007), 2000, icon))
+if addon.getSetting("ShowNotifications") == "true": 
+	xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, addon.getLocalizedString(32007), 2000, icon))
 log("-------------------------------------------------------------------------")
 log("Starting")
-backWindow = xbmcgui.Window()
-backWindow.show()
+
+# Navigate to home screen first - this will be the window we return to when playback stops
+xbmc.executebuiltin('ActivateWindow(home)')
+monitor.waitForAbort(0.2)
 busyDiag.create()
 
 
@@ -206,7 +209,6 @@ if len(myEpisodes) == 0:
 	log("--------- No episodes")
 	xbmcgui.Dialog().ok(name, addon.getLocalizedString(32008), addon.getLocalizedString(32009))
 	xbmc.executebuiltin('Addon.OpenSettings(%s)' % addonid)
-	backWindow.close()
 	log("Stopping")
 	log("-------------------------------------------------------------------------")
 	quit()
@@ -334,8 +336,21 @@ while (not monitor.abortRequested()):
 
 
 # Display Stopping Notification
-if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, addon.getLocalizedString(32011), 2000, icon))
+if addon.getSetting("ShowNotifications") == "true": 
+	xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, addon.getLocalizedString(32011), 2000, icon))
+
 busyDiag.close()
-backWindow.close()
+
+# Explicitly stop the player to avoid orphaned player instance
+if player.isPlaying():
+	log("Stopping player explicitly")
+	player.stop()
+	# Wait for player to fully stop
+	monitor.waitForAbort(0.5)
+
+# Ensure we're back on home screen
+xbmc.executebuiltin('ActivateWindow(home)')
+monitor.waitForAbort(0.2)
+
 log("Stopping")
 log("-------------------------------------------------------------------------")

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.video.randomtv" name="RandomTV" version="1.3.0" provider-name="gmccauley">
+<addon id="script.video.randomtv" name="RandomTV" version="1.3.1" provider-name="gmccauley, russ (fork)">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -34,6 +34,9 @@ It will also add a context menu item so that you can play a specific show or sea
     <forum>https://forum.kodi.tv/showthread.php?tid=310494</forum>
     <source>https://github.com/gmccauley/script.video.randomtv</source>
     <news>
+v1.3.1 (5 January 2026)
+  - Fixed black screen issue when pressing Back during playback on LibreELEC
+  - Removed empty backWindow causing window manager errors
 v1.3.0 (23 February 2021)
   - Added support for Matrix / python 3
 	</news>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+v1.3.1 (5 January 2026)
+  - Fixed black screen issue when pressing Back during playback on LibreELEC
+  - Removed empty backWindow that was causing window manager errors
+  - Added explicit player stop to prevent buffer timeout loops
+  - Improved window navigation to Home screen before playback and on exit
 v1.3.0 (23 February 2021)
   - Added support for Matrix / python 3
 v1.2.2 (11 June 2019)


### PR DESCRIPTION
Removed the empty backWindow that was causing "Window Init ()" errors when exiting fullscreen playback. The empty window was added in v1.1.2 to prevent Kodi from being displayed between shuffles, but it caused the window manager to initialize an empty window when pressing Back, resulting in black screens and orphaned player instances.

Changes:
- Removed backWindow creation and show() calls
- Navigate to Home screen before starting playback instead
- Explicitly stop player before exiting to prevent buffer timeouts
- Ensure navigation back to Home screen on cleanup

This fixes the issue where pressing Back during playback would result in a black screen with "Window Init ()" in logs and continuous "OutputPicture - timeout waiting for buffer" errors.

Tested on LibreELEC with Kodi Matrix.